### PR TITLE
Enable using FreeBSD's base system libedit

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,44 +4,41 @@ Build and make available Editline (libedit)
 
 # SYNOPSIS
 
+In your Makefile.PL:
+
+```perl
+use ExtUtils::MakeMaker;
+use Alien::Base::Wrapper ();
+
+WriteMakefile(
+  Alien::Base::Wrapper->new('Alien::Editline')->mm_args2(
+    # MakeMaker args
+    NAME => 'Kafka::Librd',
+    ...
+  ),
+);
+```
+
 In your Build.PL:
 
 ```perl
 use Module::Build;
-use Alien::Editline;
+use Alien::Base::Wrapper qw( Alien::Editline !export );
+
 my $builder = Module::Build->new(
   ...
   configure_requires => {
     'Alien::Editline' => '0',
     ...
   },
-  extra_compiler_flags => Alien::Editline->cflags,
-  extra_linker_flags   => Alien::Editline->libs,
+  Alien::Base::Wrapper->mb_args,
   ...
 );
 
 $build->create_build_script;
 ```
 
-In your Makefile.PL:
-
-```perl
-use ExtUtils::MakeMaker;
-use Config;
-use Alien::Editline;
-
-WriteMakefile(
-  ...
-  CONFIGURE_REQUIRES => {
-    'Alien::Editline' => '0',
-  },
-  CCFLAGS => Alien::Editline->cflags . " $Config{ccflags}",
-  LIBS    => [ Alien::Editline->libs ],
-  ...
-);
-```
-
-In your [FFI::Platypus](https://metacpan.org/pod/FFI::Platypus) script or module:
+In your [FFI::Platypus](https://metacpan.org/pod/FFI%3A%3APlatypus) script or module:
 
 ```perl
 use FFI::Platypus;
@@ -61,7 +58,7 @@ install it fro you.
 
 # SEE ALSO
 
-[Alien](https://metacpan.org/pod/Alien), [Alien::Base](https://metacpan.org/pod/Alien::Base), [Alien::Build::Manual::AlienUser](https://metacpan.org/pod/Alien::Build::Manual::AlienUser)
+[Alien](https://metacpan.org/pod/Alien), [Alien::Base](https://metacpan.org/pod/Alien%3A%3ABase), [Alien::Build::Manual::AlienUser](https://metacpan.org/pod/Alien%3A%3ABuild%3A%3AManual%3A%3AAlienUser)
 
 # AUTHOR
 

--- a/alienfile
+++ b/alienfile
@@ -2,6 +2,11 @@ use alienfile;
 
 plugin 'PkgConfig' => 'libedit';
 
+plugin 'Probe::CBuilder' => (
+  cflags => '-I/usr/include/edit/readline',
+  libs => '-ledit',
+);
+
 share {
 
   plugin Download => (

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -13,6 +13,7 @@ $modules{$_} = $_ for qw(
   Alien::Base
   Alien::Build
   Alien::Build::MM
+  ExtUtils::CBuilder
   ExtUtils::MakeMaker
   Test2::Bundle::Extended
   Test::Alien


### PR DESCRIPTION
On FreeBSD, libedit exists as part of the base system.  pkg-config(8)
and similar tools do not find the base system installation but will only
discover libedit if it exists on the system as part of a separately
installed package.

Listing PkgConfig before CBuilder in the alienfile prefers the package
if available, but falls back to the base system's version if present,
instead of installing from source.

The README.md changes in this commit appear to have taken place
automatically as part of the Dist::Zilla process: I did not make them
myself.